### PR TITLE
Simpler instructions wrt GitHub (and Nix for VM users)

### DIFF
--- a/src/GettingStarted.md
+++ b/src/GettingStarted.md
@@ -36,7 +36,6 @@ This will create a directory called `my-3pi` in the current working directory.
 The template includes [raspberrypi/pico-sdk](https://github.com/raspberrypi/pico-sdk) as a submodule, which itself also has a lot of submodules. We recommend against using the `--recursive` flag because we do not need to recursively clone the submodules inside of `pico-sdk`. Instead, change directory into the root of your clone and run:
 
 ```bash
-$ cd my-3pi
 $ git submodule update --init
 ```
 

--- a/src/GettingStarted.md
+++ b/src/GettingStarted.md
@@ -28,7 +28,7 @@ Give your repo a name and click on "Create repository":
 On the command line on your host machine, change directory to the location where you would like to check out your repository. Let us assume that you named your repo `my-3pi`. Check it out using the following command (where `<username>` must be substituted with your GitHub username):
 
 ```bash
-$ gh repo clone <username>/<reponame>
+$ gh repo clone <username>/my-3pi
 ```
 
 This will create a directory called `my-3pi` in the current working directory.

--- a/src/GettingStarted.md
+++ b/src/GettingStarted.md
@@ -6,25 +6,12 @@ Before getting started, please make sure you have satisfied all the [prerequisit
 If you do not yet have a GitHub account, [create one](https://github.com/signup).
 
 ### Set up authentication with GitHub
-In order to push to your repo, you need to authenticate. You can either do this using a public/private key pair through SSH, or use token-based authentication via `gh`, the GitHub command-line interface (installation instructions [here](https://github.com/cli/cli#installation)). If you want to avoid the hassle of installing a private key on it, use `gh` for authentication (recommended; pre-installed on the VM).
+If you haven't already, set up authentication with GitHub. The recommended way of doing this is using `gh`, the GitHub CLI tool. Run the following command:
 
-#### Using GitHub CLI
-To authenticate with GitHub through its CLI tool, run:
 ```bash
 $ gh auth login
 ```
-
-#### Using SSH
-In the ⚙️ [Settings](https://github.com/settings/profile) of your [GitHub account](https://github.com), go to 🔑 [SSH and GPG keys](https://github.com/settings/keys) and enter the contents of your `~/.ssh/id_rsa.pub`. If you do not have this file, create it using the following command:
-```bash
-$ ssh-keygen -t rsa -b 4096 -C "your_github@email.com"
-```
-Additional information about setting up public key authentication with GitHub can be found [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
-
-> **_Tip for VM users_**
-> 
-> If you prefer not to use `gh` for authentication and are looking for a convenient way to copy your private key onto a VM, consider using [Magic Wormhole](https://github.com/magic-wormhole/magic-wormhole). It is preinstalled on the [Ubuntu VM](https://vm.lf-lang.org) prepared for this course.
-
+Then select `> GitHub.com` and `HTTPS` if you prefer to authenticate via HTTPS, or `SSH` if you prefer to authenticate via SSH. The former uses a token and the latter uses a public/private key pair that it installs as part of the login procedure. After agreeing to authenticate Git with your GitHub credentials, select `Login with a web browser`, copy the one-time code printed on the command prompt, and press <kbd>Enter</kbd>. You will then be taken to [github.com](https://github.com/login/device) in your browser. After entering your credentials and pasting the one-time code, authentication will be completed.
 
 ## Create your repository
 Start by creating a new private repository on GitHub based on the [lf-3pi-template](https://github.com/lf-lang/lf-3pi-template) repository, which provides a starting point for students to carry out the exercises in this lab and to develop further applications using the [Raspberry Pi Pico board](https://www.raspberrypi.com/products/raspberry-pi-pico/) and the [Pololu 3pi+ 2040 robot](https://www.pololu.com/docs/0J86).
@@ -38,14 +25,7 @@ Give your repo a name and click on "Create repository":
 <img src="img/my-3pi.png" alt="new repo"/>
 
 ## Clone your repository
-On the command line on your host machine, clone the repo.
-For an SSH-based setup, run:
-
-```bash
-$ git clone git@github.com/<username>/<reponame>.git
-```
-
-Or, for a setup that uses GitHub CLI, run:
+On the command line on your host machine, clone the repo:
 
 ```bash
 $ gh repo clone <username>/<reponame>
@@ -62,6 +42,10 @@ e.g.: `6a7db34ff63345a7badec79ebea3aaef1712f374 pico-sdk (1.5.1)`.
 
 
 ## Configure Nix
+
+> **_Note for VM users_**
+>
+> If you are using the [VM image](https://vm.lf-lang.org/), you can skip this step. You will never have to invoke `nix` and can ignore any reminders about doing this.
 
 To create a reproducible unix shell environment that installs all required dependency applications, we use the [nix](https://nixos.org) package manager, which has support for Linux, macOS, and Windows (via WSL). See [prerequisites](Prerequisites.html) for installation instructions. If you prefer to manage dependencies yourself and not rely on `nix`, follow the [instructions for a non-`nix` setup](Non-Nix.html).
 

--- a/src/GettingStarted.md
+++ b/src/GettingStarted.md
@@ -25,21 +25,30 @@ Give your repo a name and click on "Create repository":
 <img src="img/my-3pi.png" alt="new repo"/>
 
 ## Clone your repository
-On the command line on your host machine, clone the repo:
+On the command line on your host machine, change directory to the location where you would like to check out your repository. Let us assume that you named your repo `my-3pi`. Check it out using the following command (where `<username>` must be substituted with your GitHub username):
 
 ```bash
 $ gh repo clone <username>/<reponame>
 ```
 
+This will create a directory called `my-3pi` in the current working directory.
+
 The template includes [raspberrypi/pico-sdk](https://github.com/raspberrypi/pico-sdk) as a submodule, which itself also has a lot of submodules. We recommend against using the `--recursive` flag because we do not need to recursively clone the submodules inside of `pico-sdk`. Instead, change directory into the root of your clone and run:
 
 ```bash
+$ cd my-3pi
 $ git submodule update --init
 ```
 
-If  `pico-sdk` was checked out correctly, `git submodule` will show the hash _without_ a `-` preceding it,
+If  `pico-sdk` was checked out correctly running `git submodule` in the root of the repository will show the hash _without_ a `-` preceding it,
 e.g.: `6a7db34ff63345a7badec79ebea3aaef1712f374 pico-sdk (1.5.1)`.
 
+> **_Note for existing GitHub users_**
+>
+> If you are an existing GitHub user and have already set up a public/private key pair (or have done so by selecting `SSH` as the protocol when running `gh auth login`), you can also clone the repo as follows:
+> ```
+> $ git clone git@github.com/<username>/<reponame>.git
+> ```
 
 ## Configure Nix
 

--- a/src/Non-Nix.md
+++ b/src/Non-Nix.md
@@ -21,11 +21,21 @@ $ echo "export PICO_SDK_PATH=$PICO_SDK_PATH" >> ~/.profile
 __Caution__: Depending on what operating system and terminal you use, you may need to find some other way to set this environment variable.
 
 ## Install `picotool`
-To build and install `picotool` from source, refer to the [raspberrypi/picotool](https://github.com/raspberrypi/picotool) repository.
+To build and install `picotool` from source, run the following commands:
+
+```bash
+$ git clone https://github.com/raspberrypi/picotool.git
+$ cd picotool
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+$ sudo make install
+```
 
 ## Install CMake, Standard C Library, ARM cross compiler
 
-See also the [GNU ARM installation instructions](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
+For reference, see the [GNU ARM installation instructions](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads). For installation instructions specific to Ubuntu and macOS, read on.
 
 ### On Ubuntu
 

--- a/src/Non-Nix.md
+++ b/src/Non-Nix.md
@@ -4,11 +4,12 @@ If you use `nix` as explained in the [getting started instructions](./GettingSta
 
 ## Install Raspberry Pi Pico SDK
 
-Clone the [raspberrypi/pico-sdk](https://github.com/raspberrypi/pico-sdk) repository and set the `PICO_SDK_PATH` environment variable:
+Clone the [raspberrypi/pico-sdk](https://github.com/raspberrypi/pico-sdk) repository (and its submodules) and set the `PICO_SDK_PATH` environment variable:
 
 ```bash
 $ git clone https://github.com/raspberrypi/pico-sdk.git
 $ cd pico-sdk
+$ git submodule update --init
 $ export PICO_SDK_PATH=`pwd`
 ```
 
@@ -18,7 +19,7 @@ For convenience, set `PICO_SDK_PATH` in your `~/.profile` file so that the envir
 $ echo "export PICO_SDK_PATH=$PICO_SDK_PATH" >> ~/.profile
 ```
 
-__Caution__: Depending on what operating system and terminal you use, you may need to find some other way to set this environment variable.
+__Caution__: Depending on what operating system and terminal you use, and how it is configured, you may need to find some other way to set this environment variable.
 
 ## Install `picotool`
 To build and install `picotool` from source, run the following commands:

--- a/src/Prerequisites.md
+++ b/src/Prerequisites.md
@@ -4,7 +4,8 @@ Before [getting started](./GettingStarted.html), please check whether you have a
 Alternatively, a pre-configured Ubuntu VM image is available [here](https://vm.lf-lang.org). Instructions for usage of the VM are provided [here](UbuntuVM.html).
 
 ## Packages
-Your system must have the following (very common) software packages installed:
+Your system must have the following (very common) software packages installed (we recommend using your favorite package manager to install them):
+ - `gh` — [a CLI tool for interaction with GitHub](https://cli.github.com/)
  - `git` — [a distributed version control system](https://git-scm.com/)
  - `cmake` — [a cross-platform family of tools for building, testing and packaging software](https://cmake.org/)
  - `code` — [the Visual Studio Code IDE](https://code.visualstudio.com/download)
@@ -12,8 +13,6 @@ Your system must have the following (very common) software packages installed:
  - `java` — [Java 17](https://openjdk.org/projects/jdk/17)
  - `nix` — [a purely functional package manager](https://nix.dev/tutorials/install-nix)
  - `screen` — [a terminal multiplexer](https://dev.to/thiht/learn-to-use-screen-a-terminal-multiplexer-gl)
-
-We recommend using your favorite package manager to install them.
 
 ### Installation on Ubuntu
 ```bash

--- a/src/README.md
+++ b/src/README.md
@@ -8,7 +8,10 @@ The C code runs on a [Raspberry Pi RP2040](https://en.wikipedia.org/wiki/RP2040)
 on the [Pololu 3pi+ 2040 robot](https://www.pololu.com/docs/0J86). 
 The same RP2040 microprocessor is also available on the low-cost [Raspberry Pi Pico board](https://en.wikipedia.org/wiki/Raspberry_Pi#Raspberry_Pi_Pico), but this board does not have the sensors and actuators of the Pololu robot, so you will need the robot to be able to complete all the exercises.
 
-## Acknowlegments
+## Contributing
+You can find the Markdown sources of these labs on [GitHub](https://github.com/lf-lang/embedded-lab). If you discover any problems, please consider creating an [issue](https://github.com/lf-lang/embedded-lab/issues) or submitting a [pull request](https://github.com/lf-lang/embedded-lab/pulls).
+
+## Acknowledgments
 
 The main authors of this version of the labs are:
 


### PR DESCRIPTION
There simplifications are possible as we decided to:
 - add `gh` as a prerequisite because it's really convenient; and
 - include the dependencies normally managed by `nix` in the VM image.