### PR TITLE
Minor fixes

### DIFF
--- a/src/Debugger.md
+++ b/src/Debugger.md
@@ -91,7 +91,7 @@ target C {
     name: "rp2040",
     board: "pololu_3pi_2040_robot"
   },
-  threading: false,
+  single-threaded: true,
   build-type: debug
 }
 ```
@@ -152,7 +152,7 @@ In a separate terminal window, run the following `gdb` session specifying the `.
 gdb bin/Blink.elf
 ```
 Once the GDB environment is opened, connect to the debug server using the following. Each of the two cores exposes its own port.
-With `threading` set to `false` in the target directive, `core0` runs the main thread, so you want to connect gdb to port `3333`:
+With `single-threaded` set to `true` in the target directive, `core0` runs the main thread, so you want to connect gdb to port `3333`:
 
 ```bash
 (gdb) target extended-remote localhost:3333

--- a/src/Interrupts.md
+++ b/src/Interrupts.md
@@ -54,7 +54,7 @@ sure to understand static variables in C.
         name: "rp2040",
         board: "pololu_3pi_2040_robot"
       },
-      threading: false,
+      single-threaded: true,
       keepalive: true
     }
     ```

--- a/src/Sensors.md
+++ b/src/Sensors.md
@@ -81,9 +81,9 @@ You should see the display light up looking something like this:
 
     2. Notice the `target` specification at the top of each of the .lf files.  What do you think is the significance of the directive:
     
-        ```threading: false```
+        ```single-threaded: true```
         
-    **CHECKOFF:** Explain what the four reactions do and the importance of threading being turned off.
+    **CHECKOFF:** Explain what the four reactions do and the importance of single-threaded being turned on.
 
 ## 4.3 Measuring Tilt
 

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -277,6 +277,8 @@ $ screen -r
 
 To permanently end screen, type Control-A k (for kill).
 
+If screen immediately exits with the message `[screen is terminating]`, you might need to execute it with root rights.
+
 **Checkoff:** Show ON-OFF output.    
 
 ## 3.5 Modular Reusable Reactors
@@ -294,7 +296,7 @@ target C {
     name: "rp2040",
     board: "pololu_3pi_2040_robot"
   },
-  threading: false,
+  single-threaded: true: false,
 }
 preamble {=
   #include <hardware/gpio.h>
@@ -316,7 +318,7 @@ Then create a new LF file called `ToolsLEDSolution.lf` that imports this reactor
 
 - [Inputs and Outputs](https://www.lf-lang.org/docs/handbook/inputs-and-outputs?target=c)
 - [Composing Reactors](https://www.lf-lang.org/docs/handbook/composing-reactors?target=c)
-- [Reactions and Methods](https://www.lf-lang.org/docs/handbook/reactions-and-methods?target=c)
+- [Reactions](https://www.lf-lang.org/docs/handbook/reactions?target=c)
 
 You have probably noticed some patterns here. E.g., each LF file begins with this:
 
@@ -326,11 +328,11 @@ target C {
     name: "rp2040",
     board: "pololu_3pi_2040_robot"
   },
-  threading: false,
+  single-threaded: true,
 }
 ```
 
-This specifies that the target language is C, so the `lfc` compiler generates C programs. The platform specification indicates that the C runtime system for the Raspberry Pi 2040 should be used and that the target board is the Pololu robot.  The `threading` directive indicates that the target is bare metal machine with no operating system and no thread library.
+This specifies that the target language is C, so the `lfc` compiler generates C programs. The platform specification indicates that the C runtime system for the Raspberry Pi 2040 should be used and that the target board is the Pololu robot.  The `single-threaded` directive indicates that the target is bare metal machine with no operating system and no thread library.
 
 To initialize and toggle the LED, we are using library functions like `gpio_put` which are declared in a header file `gpio.h` that is part of the standard Pico SDK.
 Inclusion of this header file is a consequence of this directive:


### PR DESCRIPTION
Fixed some minor issues on the pages:
- `screen` needs sudo (on my machine it just shows a non-descriptive "screen is terminating", the explanation should clarify this)
- threading directive replaced by single-threaded,
- fixed broken link (Reactions and Methods page has been broken up into two, the former seems to be referred to here)