### PR TITLE
Publish Track and Line Following exercise and add contributors

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -16,6 +16,8 @@ You can find the Markdown sources of these labs on [GitHub](https://github.com/l
 The main authors of this version of the labs are:
 
 - Abhi Gundrala
+- Aditya Krishnan 
+- Hokeun Kim
 - Edward A. Lee
 - Marten Lohstroh
 
@@ -28,6 +30,7 @@ These labs are derived from several generations of lab exercises for the Berkele
 - Abhi Gudrala
 - Jeff C. Jensen
 - Eric S. Kim
+- Hokeun Kim
 - Edward A. Lee
 - Shaokai Lin
 - Sanjit Seshia

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Interrupts](./Interrupts.md)
 - [Robot](./Robot.md)
 - [Hill Climb](./Hill.md)
+- [Track and Line Following](./Line.md)
 
 # Appendices
 


### PR DESCRIPTION
Verified this with `mdbook serve`.
A new **Track and Line Following** exercise was created by Aditya and Hokeun. Hokeun was one of the early contributors to the EECS 149 lab at Berkeley.