### PR TITLE
Fix of the issue with the Pico SDK version mismatch between pico-examples and lf-3pi-template

### DIFF
--- a/src/Prerequisites.md
+++ b/src/Prerequisites.md
@@ -4,20 +4,17 @@ Before [getting started](./GettingStarted.html), please check whether you have a
 Alternatively, a pre-configured Ubuntu VM image is available [here](https://vm.lf-lang.org). Instructions for usage of the VM are provided [here](UbuntuVM.html).
 
 ## Packages
-
 Your system must have the following (very common) software packages installed (we recommend using your favorite package manager to install them):
-
-- `gh` — [a CLI tool for interaction with GitHub](https://cli.github.com/)
-- `git` — [a distributed version control system](https://git-scm.com/)
-- `cmake` — [a cross-platform family of tools for building, testing and packaging software](https://cmake.org/)
-- `code` — [the Visual Studio Code IDE](https://code.visualstudio.com/download)
-- `curl` — [a CLI tool and library for transfering data with URLs](https://curl.se/)
-- `java` — [Java 17](https://openjdk.org/projects/jdk/17)
-- `nix` — [a purely functional package manager](https://nix.dev/tutorials/install-nix)
-- `screen` — [a terminal multiplexer](https://dev.to/thiht/learn-to-use-screen-a-terminal-multiplexer-gl)
+ - `gh` — [a CLI tool for interaction with GitHub](https://cli.github.com/)
+ - `git` — [a distributed version control system](https://git-scm.com/)
+ - `cmake` — [a cross-platform family of tools for building, testing and packaging software](https://cmake.org/)
+ - `code` — [the Visual Studio Code IDE](https://code.visualstudio.com/download)
+ - `curl` — [a CLI tool and library for transfering data with URLs](https://curl.se/)
+ - `java` — [Java 17](https://openjdk.org/projects/jdk/17)
+ - `nix` — [a purely functional package manager](https://nix.dev/tutorials/install-nix)
+ - `screen` — [a terminal multiplexer](https://dev.to/thiht/learn-to-use-screen-a-terminal-multiplexer-gl)
 
 ### Installation on Ubuntu
-
 ```bash
 $ sudo apt update
 $ sudo apt install gh git curl openjdk-17-jdk openjdk-17-jre nix screen cmake
@@ -25,7 +22,6 @@ $ sudo snap install code --classic
 ```
 
 ### Installation on macOS
-
 ```bash
 $ brew install --cask visual-studio-code
 $ brew install gh git cmake curl openjdk@17 screen
@@ -33,15 +29,12 @@ $ curl -L https://nixos.org/nix/install | sh
 ```
 
 ## Lingua Franca Toolchain
-
 To install the nightly (recommended) Lingua Franca CLI tools (i.e, the compiler `lfc`, the diagram generator `lfd`, and the code formatter `lff`), run:
-
 ```
 curl -Ls https://install.lf-lang.org | bash -s nightly cli
 ```
 
 If you prefer an Eclipse-based IDE over the Lingua Franca VS Code extension, install the nightly build of `epoch` using the following command:
-
 ```
 curl -Ls https://install.lf-lang.org | bash -s nightly epoch
 ```
@@ -49,14 +42,11 @@ curl -Ls https://install.lf-lang.org | bash -s nightly epoch
 > **_Troubleshooting for permission denied error_**
 >
 > If you get a permission denied error while running the command above (the error will look like below):
->
 > ```
 > > Creating directory /usr/local/share/lingua-franca
 > mkdir: /usr/local/share/lingua-franca: Permission denied
 > ```
->
 > Try running the following commands which download the installation shell script and run the script with sudo:
->
 > ```bash
 > wget https://raw.githubusercontent.com/lf-lang/installation/main/install.sh
 > chmod +x install.sh
@@ -64,19 +54,15 @@ curl -Ls https://install.lf-lang.org | bash -s nightly epoch
 > ```
 
 ## VS Code extensions
-
 Please ensure that you have the following extensions installed:
-
-- `ms-vscode.cmake-tools` — [Extended CMake support in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
-- `ms-vscode.cpptools` — [C/C++ IntelliSense, debugging, and code browsing](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
-- `lf-lang.vscode-lingua-franca` — [Lingua Franca for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=lf-lang.vscode-lingua-franca)
+ - `ms-vscode.cmake-tools` — [Extended CMake support in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
+ - `ms-vscode.cpptools` — [C/C++ IntelliSense, debugging, and code browsing](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
+ - `lf-lang.vscode-lingua-franca` — [Lingua Franca for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=lf-lang.vscode-lingua-franca)
 
 For debugging support in VS Code:
-
-- `marus25.cortex-debug` — [ARM Cortex-M GDB Debugger support for VSCode](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
+ - `marus25.cortex-debug` — [ARM Cortex-M GDB Debugger support for VSCode](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
 
 To install them from the command line, run:
-
 ```bash
 $ code --install-extension ms-vscode.cmake-tools
 $ code --install-extension ms-vscode.cpptools
@@ -87,7 +73,6 @@ $ code --install-extension marus25.cortex-debug
 ## Permissions
 
 ### Using `nix` on Linux/WSL
-
 To use `nix` on Linux, make sure that your user is a member of the `nix-users` group. To check this, run:
 
 ```bash
@@ -103,9 +88,7 @@ $ sudo usermod -aG nix-users $USER
 Please note that you might need to reboot your system after running `usermod` in order for the new group membership to be reflected.
 
 ### Using `picotool` on Linux/WSL
-
 To allow access to the RP2040 via USB without superuser privileges, add custom `udev` rules using the following command:
-
 ```bash
 $ curl -s https://raw.githubusercontent.com/raspberrypi/picotool/master/udev/99-picotool.rules | sudo tee -a /etc/udev/rules.d/99-picotool.rules >/dev/null
 ```

--- a/src/Prerequisites.md
+++ b/src/Prerequisites.md
@@ -20,7 +20,7 @@ Your system must have the following (very common) software packages installed (w
 
 ```bash
 $ sudo apt update
-$ sudo apt install gh git curl openjdk-17-jdk openjdk-17-jre nix screen
+$ sudo apt install gh git curl openjdk-17-jdk openjdk-17-jre nix screen cmake
 $ sudo snap install code --classic
 ```
 

--- a/src/Prerequisites.md
+++ b/src/Prerequisites.md
@@ -4,23 +4,28 @@ Before [getting started](./GettingStarted.html), please check whether you have a
 Alternatively, a pre-configured Ubuntu VM image is available [here](https://vm.lf-lang.org). Instructions for usage of the VM are provided [here](UbuntuVM.html).
 
 ## Packages
+
 Your system must have the following (very common) software packages installed (we recommend using your favorite package manager to install them):
- - `gh` — [a CLI tool for interaction with GitHub](https://cli.github.com/)
- - `git` — [a distributed version control system](https://git-scm.com/)
- - `cmake` — [a cross-platform family of tools for building, testing and packaging software](https://cmake.org/)
- - `code` — [the Visual Studio Code IDE](https://code.visualstudio.com/download)
- - `curl` — [a CLI tool and library for transfering data with URLs](https://curl.se/)
- - `java` — [Java 17](https://openjdk.org/projects/jdk/17)
- - `nix` — [a purely functional package manager](https://nix.dev/tutorials/install-nix)
- - `screen` — [a terminal multiplexer](https://dev.to/thiht/learn-to-use-screen-a-terminal-multiplexer-gl)
+
+- `gh` — [a CLI tool for interaction with GitHub](https://cli.github.com/)
+- `git` — [a distributed version control system](https://git-scm.com/)
+- `cmake` — [a cross-platform family of tools for building, testing and packaging software](https://cmake.org/)
+- `code` — [the Visual Studio Code IDE](https://code.visualstudio.com/download)
+- `curl` — [a CLI tool and library for transfering data with URLs](https://curl.se/)
+- `java` — [Java 17](https://openjdk.org/projects/jdk/17)
+- `nix` — [a purely functional package manager](https://nix.dev/tutorials/install-nix)
+- `screen` — [a terminal multiplexer](https://dev.to/thiht/learn-to-use-screen-a-terminal-multiplexer-gl)
 
 ### Installation on Ubuntu
+
 ```bash
+$ sudo apt update
 $ sudo apt install gh git curl openjdk-17-jdk openjdk-17-jre nix screen
 $ sudo snap install code --classic
 ```
 
 ### Installation on macOS
+
 ```bash
 $ brew install --cask visual-studio-code
 $ brew install gh git cmake curl openjdk@17 screen
@@ -28,12 +33,15 @@ $ curl -L https://nixos.org/nix/install | sh
 ```
 
 ## Lingua Franca Toolchain
+
 To install the nightly (recommended) Lingua Franca CLI tools (i.e, the compiler `lfc`, the diagram generator `lfd`, and the code formatter `lff`), run:
+
 ```
 curl -Ls https://install.lf-lang.org | bash -s nightly cli
 ```
 
 If you prefer an Eclipse-based IDE over the Lingua Franca VS Code extension, install the nightly build of `epoch` using the following command:
+
 ```
 curl -Ls https://install.lf-lang.org | bash -s nightly epoch
 ```
@@ -41,11 +49,14 @@ curl -Ls https://install.lf-lang.org | bash -s nightly epoch
 > **_Troubleshooting for permission denied error_**
 >
 > If you get a permission denied error while running the command above (the error will look like below):
+>
 > ```
 > > Creating directory /usr/local/share/lingua-franca
 > mkdir: /usr/local/share/lingua-franca: Permission denied
 > ```
+>
 > Try running the following commands which download the installation shell script and run the script with sudo:
+>
 > ```bash
 > wget https://raw.githubusercontent.com/lf-lang/installation/main/install.sh
 > chmod +x install.sh
@@ -53,15 +64,19 @@ curl -Ls https://install.lf-lang.org | bash -s nightly epoch
 > ```
 
 ## VS Code extensions
+
 Please ensure that you have the following extensions installed:
- - `ms-vscode.cmake-tools` — [Extended CMake support in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
- - `ms-vscode.cpptools` — [C/C++ IntelliSense, debugging, and code browsing](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
- - `lf-lang.vscode-lingua-franca` — [Lingua Franca for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=lf-lang.vscode-lingua-franca)
+
+- `ms-vscode.cmake-tools` — [Extended CMake support in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
+- `ms-vscode.cpptools` — [C/C++ IntelliSense, debugging, and code browsing](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
+- `lf-lang.vscode-lingua-franca` — [Lingua Franca for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=lf-lang.vscode-lingua-franca)
 
 For debugging support in VS Code:
- - `marus25.cortex-debug` — [ARM Cortex-M GDB Debugger support for VSCode](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
+
+- `marus25.cortex-debug` — [ARM Cortex-M GDB Debugger support for VSCode](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
 
 To install them from the command line, run:
+
 ```bash
 $ code --install-extension ms-vscode.cmake-tools
 $ code --install-extension ms-vscode.cpptools
@@ -72,6 +87,7 @@ $ code --install-extension marus25.cortex-debug
 ## Permissions
 
 ### Using `nix` on Linux/WSL
+
 To use `nix` on Linux, make sure that your user is a member of the `nix-users` group. To check this, run:
 
 ```bash
@@ -87,7 +103,9 @@ $ sudo usermod -aG nix-users $USER
 Please note that you might need to reboot your system after running `usermod` in order for the new group membership to be reflected.
 
 ### Using `picotool` on Linux/WSL
+
 To allow access to the RP2040 via USB without superuser privileges, add custom `udev` rules using the following command:
+
 ```bash
 $ curl -s https://raw.githubusercontent.com/raspberrypi/picotool/master/udev/99-picotool.rules | sudo tee -a /etc/udev/rules.d/99-picotool.rules >/dev/null
 ```

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -92,6 +92,7 @@ First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pic
 $ cd ~
 $ git clone https://github.com/raspberrypi/pico-examples.git
 $ cd pico-examples
+$ git checkout c95295f830a68a4854f822f07ef1b9b5abc3079e
 ```
 
 Make a blank `build` directory and use it to compile all the examples:

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -86,7 +86,7 @@ If the environment variable `PICO_SDK_PATH` is not set, simply run `nix develop`
 
 ### Using the Command Line
 
-First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pico-examples) repository **inside the cloned directory in `my-3pi`** and make it your current working directory.
+First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pico-examples) repository (for example, in your home directory) and make it your current working directory:
 Also, make sure to checkout to `c95295f830a68a4854f822f07ef1b9b5abc3079e` since SDK version updates have been made in the newest version of the `pico-examples`.
 
 ```bash

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -90,7 +90,7 @@ First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pic
 Also, make sure to checkout to `c95295f830a68a4854f822f07ef1b9b5abc3079e` since SDK version updates have been made in the newest version of the `pico-examples`.
 
 ```bash
-$ cd /path/to/my-3pi
+$ cd ~
 $ git clone https://github.com/raspberrypi/pico-examples.git
 $ cd pico-examples
 $ git checkout c95295f830a68a4854f822f07ef1b9b5abc3079e

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -87,7 +87,13 @@ If the environment variable `PICO_SDK_PATH` is not set, simply run `nix develop`
 ### Using the Command Line
 
 First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pico-examples) repository (for example, in your home directory) and make it your current working directory:
-Also, make sure to checkout to `c95295f830a68a4854f822f07ef1b9b5abc3079e` since SDK version updates have been made in the newest version of the `pico-examples`.
+
+> **_Note_**
+>
+> As of September 2024, we need to check out the specific commit version (`c95295f830a68a4854f822f07ef1b9b5abc3079e`) as shown below
+> because the current template uses Raspberry Pi Pico SDK version 1.5.1,
+> while the current version of `pico-examples` requires Pico SDK version 2.0.0.
+
 
 ```bash
 $ cd ~

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -86,10 +86,11 @@ If the environment variable `PICO_SDK_PATH` is not set, simply run `nix develop`
 
 ### Using the Command Line
 
-First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pico-examples) repository (for example, in your home directory) and make it your current working directory:
+First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pico-examples) repository **inside the cloned directory in `my-3pi`** and make it your current working directory.
+Also, make sure to checkout to `c95295f830a68a4854f822f07ef1b9b5abc3079e` since SDK version updates have been made in the newest version of the `pico-examples`.
 
 ```bash
-$ cd ~
+$ cd /path/to/my-3pi
 $ git clone https://github.com/raspberrypi/pico-examples.git
 $ cd pico-examples
 $ git checkout c95295f830a68a4854f822f07ef1b9b5abc3079e

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -91,7 +91,7 @@ First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pic
 > **_Note_**
 >
 > As of September 2024, we need to check out the specific commit version (`c95295f830a68a4854f822f07ef1b9b5abc3079e`) as shown below
-> because the current template uses Raspberry Pi Pico SDK version 1.5.1,
+> because the current template (`lf-3pi-template`) uses Raspberry Pi Pico SDK version 1.5.1,
 > while the current version of `pico-examples` requires Pico SDK version 2.0.0.
 
 

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -94,7 +94,6 @@ First, clone the [raspberry-pi/pico-examples](https://github.com/raspberrypi/pic
 > because the current template (`lf-3pi-template`) uses Raspberry Pi Pico SDK version 1.5.1,
 > while the current version of `pico-examples` requires Pico SDK version 2.0.0.
 
-
 ```bash
 $ cd ~
 $ git clone https://github.com/raspberrypi/pico-examples.git


### PR DESCRIPTION
- Add `sudo apt update`, due to "Unable to locate package" errors.
- Add to install cmake.
- Fix issue #26.
  - Add instructions to checkout to older version. `git checkout c95295f830a68a4854f822f07ef1b9b5abc3079e`
- Add instructions to make sure to install `pico-examples` repo "inside" the `my-3pi` repo.