### PR TITLE
Add instructions for WSL users to use usbipd for RP2040 access

### DIFF
--- a/src/Tools.md
+++ b/src/Tools.md
@@ -133,7 +133,9 @@ You can disconnect the robot and use the power button to start it running on bat
 >    picotool was unable to connect. Maybe try 'sudo' or check your permissions.
 > ```
 > If you see this message, this means that your user does not have permission to access the RP2040 via USB.
-> You can add `udev` rules to allow regular users to access the PR2040, as described [here](Prerequisites.html#using-picotool-on-linuxwsl).
+> You can add `udev` rules to allow regular users to access the RP2040, as described [here](Prerequisites.html#using-picotool-on-linuxwsl).
+
+> For WSL users, `usbipd` is required to install and used in Windows Powershell under Admin. Please check [here](Windows.html#wsl-setup).
 
 ### Using VS Code
 


### PR DESCRIPTION
The `Notes for Windows` page was not linked properly, when trying to access the RP2040 via USB, using WSL.
This PR adds a link to this page.

+ small typo fix on `PR2040` to `RP2040`.

Thanks for @SakshiKhade and @JFelix000.