### PR TITLE
Update of workaround instructions for superuser privileges of picotool on Linux/WSL, `99-picotool.rules` to `60-picotool.rules`, because of the change in `picotool` repo

### DIFF
--- a/src/Prerequisites.md
+++ b/src/Prerequisites.md
@@ -90,5 +90,5 @@ Please note that you might need to reboot your system after running `usermod` in
 ### Using `picotool` on Linux/WSL
 To allow access to the RP2040 via USB without superuser privileges, add custom `udev` rules using the following command:
 ```bash
-$ curl -s https://raw.githubusercontent.com/raspberrypi/picotool/master/udev/99-picotool.rules | sudo tee -a /etc/udev/rules.d/99-picotool.rules >/dev/null
+$ curl -s https://raw.githubusercontent.com/raspberrypi/picotool/master/udev/60-picotool.rules | sudo tee -a /etc/udev/rules.d/60-picotool.rules >/dev/null
 ```


### PR DESCRIPTION
```
$ curl -s https://raw.githubusercontent.com/raspberrypi/picotool/master/udev/99-picotool.rules | sudo tee -a /etc/udev/rules.d/99-picotool.rules >/dev/null
```
99-picotool.rules has been changed to 60-picotool.rules

This change has been made in the picotool repo with this PR in May 2025: https://github.com/raspberrypi/picotool/pull/230