### PR TITLE
Remove references to pre-configured VM

### DIFF
--- a/src/GettingStarted.md
+++ b/src/GettingStarted.md
@@ -53,9 +53,6 @@ This will create a directory called `my-3pi` in the current working directory.
 > The reason for this is that the key used by `github.com` is not yet known by your machine.
 > Once you type `yes` and <kbd>Enter</kbd>, the fingerprint of GitHub's public key will be added to `~/.ssh/known_hosts`. Only when GitHub _changes_ its public key will this warning reappear. This feature of SSH is meant to avoid [man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).
 
-> **_Note for VM users_**
-> If you are using the [VM image](https://vm.lf-lang.org/), you can skip the subsequent step; you do not have to update or initialize the `pico-sdk` submodule in your repository because it is already present in `~/pico-sdk`.
-
 The template includes [raspberrypi/pico-sdk](https://github.com/raspberrypi/pico-sdk) as a submodule, which itself also has a lot of submodules. We recommend against using the `--recursive` flag because we do not need to recursively clone the submodules inside of `pico-sdk`. Instead, change directory into the root of your clone and run:
 
 ```bash
@@ -66,10 +63,6 @@ If  `pico-sdk` was checked out correctly running `git submodule` in the root of 
 e.g.: `6a7db34ff63345a7badec79ebea3aaef1712f374 pico-sdk (1.5.1)`.
 
 ## Configure Nix
-
-> **_Note for VM users_**
->
-> If you are using the [VM image](https://vm.lf-lang.org/), you can skip this step. You will never have to invoke `nix` and can ignore any reminders about doing this. 
 
 To create a reproducible unix shell environment that installs all required dependency applications, we use the [nix](https://nixos.org) package manager, which has support for Linux, macOS, and Windows (via WSL). See [prerequisites](Prerequisites.html) for installation instructions. If you prefer to manage dependencies yourself and not rely on `nix`, follow the [instructions for a non-`nix` setup](Non-Nix.html).
 

--- a/src/Prerequisites.md
+++ b/src/Prerequisites.md
@@ -1,7 +1,6 @@
 # Prerequisites
 
 Before [getting started](./GettingStarted.html), please check whether you have all the necessary software installed and configured properly.
-Alternatively, a pre-configured Ubuntu VM image is available [here](https://vm.lf-lang.org). Instructions for usage of the VM are provided [here](UbuntuVM.html).
 
 ## Packages
 Your system must have the following (very common) software packages installed (we recommend using your favorite package manager to install them):

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -28,8 +28,6 @@
 
 ---
 
-[Notes for VM users](./UbuntuVM.md)
-
 [Notes for Windows Users](./Windows.md)
 
 [Notes for Instructors](./Instructors.md)

--- a/src/Tools.md
+++ b/src/Tools.md
@@ -162,9 +162,6 @@ You should select the `arm-none-eabi` kit. If you do not see one, select "Scan f
 > <img src="img/ConfigurationProvider.png" alt="Configuration Provider" width="60%"/>
 > If CMake Tools is not available, then the cmake extension is not installed in VS Code.
 
-> **_Note for VM users_**
-> If you are using the [VM image](https://vm.lf-lang.org/), click on "No kit selected" and you should be able to find the `arm-non-eabi` kit in the drop-down menu. You might also be unable to find the `CMake Tools (active)` as above, but compilation should still work.
-
 If all goes well, VS Code will have configured and generated all the build files, and you see output something like this:
 
 <img src="img/CompileOutput.png" alt="Compile output"/>
@@ -258,10 +255,6 @@ On Linux, the device is likely to appear in the `/dev` directory under a name th
 ```bash
 $ ls /dev/ttyACM*
 ```
-
-> **_Note for VM users_**
-> `ttyACM\*` cannot be found when Pololu is in BOOTSEL mode. To find it, press `RESET`, choose the USB device (in VirtualBox: `Device` -> `USB` -> `Raspberry Pi RP2 Boot`), and you should be able to see it under `/dev`.
-
 
 ## Using `screen`
 


### PR DESCRIPTION
There is no pre-configured VM at the location specified. It seems from the comments throughout that the pre-configured VM never really worked very well because of access problems to the USB ports, so I think it is best to just remove this.